### PR TITLE
tox.ini: exit non-zero if any command fails

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,9 @@ setenv =
 deps =
     dzcb~=0.1
 commands =
-    /usr/bin/env find {toxinidir}/input \
-        -name "generate.sh" \
-        {env:FIND_OPTS} -exec \{\} ;
+    /usr/bin/env bash -c " \
+	find {toxinidir}/input \
+		-name "generate.sh" \
+		{env:FIND_OPTS} -print0 | \
+	xargs -0 -n 1 bash \
+    "


### PR DESCRIPTION
`find` only exits non-zero if finding something failed, ignoring any
exec'd program exit status.

use bash and xargs to preserve the non-zero exit status